### PR TITLE
add show subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ $ pip install backwork-upload-cos
 
 ## Using
 
-After installing the plug-in you will be able to use the `upload cos` and `download cos`
+After installing the plug-in you will be able to use the `upload cos`, `show cos`, and `download cos`
 commands on `backwork`.
+
+### `backwork upload cos`
 
 ```sh
 $ backwork upload cos --help
@@ -41,6 +43,53 @@ optional arguments:
   -p SECRET_KEY, --secret-key SECRET_KEY
                         secret access key of HMAC credentials
 ```
+
+### `backwork show cos`
+
+list backups
+```sh
+usage: backwork show cos [-h] [-e ENDPOINT_URL] [-s INSTANCE_ID]
+                         [-u ACCESS_KEY] [-p SECRET_KEY] [-l LIMIT]
+                         [--sort-last-modified]
+                         bucket path
+
+List available backups in Cloud Object Storage.
+
+positional arguments:
+  bucket                target s3 bucket
+  path                  Path/prefix to the look for backups in
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -e ENDPOINT_URL, --endpoint-url ENDPOINT_URL
+                        endpoint URL of the S3 storage
+  -s INSTANCE_ID, --instance-id INSTANCE_ID
+                        service instance id
+  -u ACCESS_KEY, --access-key ACCESS_KEY
+                        acccess key id of HMAC credentials
+  -p SECRET_KEY, --secret-key SECRET_KEY
+                        secret access key of HMAC credentials
+  -l LIMIT, --limit LIMIT
+                        max number of results to return
+  --sort-last-modified  if passed, sorts results from most to least recent
+```
+
+A common use case would be to get the name of the most recent backup:
+
+```sh
+backwork show cos \
+  --endpoint-url "${IBM_COS_ENDPOINT_URL}" \
+  --instance-id "${IBM_COS_INSTANCE_ID}" \
+  --access-key "${IBM_COS_ACCESS_KEY}" \
+  --secret-key "${IBM_COS_SECRET_KEY}" \
+  "my-bucket" \
+  "my-path" \
+  --limit 1 \
+  --sort-last-modified \
+  | jq .backups[0]
+```
+
+### `backwork download cos`
 
 ```sh
 $ backwork download cos --help

--- a/cos/__init__.py
+++ b/cos/__init__.py
@@ -1,4 +1,5 @@
 """Upload file to IBM Cloud Object Storage."""
 
 from .cos import CloudObjectStorageUpload
+from .cos import CloudObjectStorageShow
 from .cos import CloudObjectStorageDownload

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
         "backwork.uploads": [
             "cos=cos:CloudObjectStorageUpload"
         ],
+        "backwork.shows": [
+            "cos=cos:CloudObjectStorageShow"
+        ],
         "backwork.downloads": [
             "cos=cos:CloudObjectStorageDownload"
         ]


### PR DESCRIPTION
Related: https://github.com/IBM/backwork/pull/2

Adds a show subcommand to upload modules. It's useful to be able to list the existing backups before using the download command.